### PR TITLE
Fix parser flag

### DIFF
--- a/add-hevc-ffmpeg-decoder-parser.js
+++ b/add-hevc-ffmpeg-decoder-parser.js
@@ -159,7 +159,7 @@ function enableHevcConfig(filename) {
     .replace('define CONFIG_BSWAPDSP 0', 'define CONFIG_BSWAPDSP 1')
     .replace('define CONFIG_DOVI_RPU 0', 'define CONFIG_DOVI_RPU 1')
     .replace("--enable-decoder='aac,h264'", "--enable-decoder='aac,h264,hevc'")
-    .replace("--enable-parser='aac,h264'", "--enable-decoder='aac,h264,hevc'");
+    .replace("--enable-parser='aac,h264'", "--enable-parser='aac,h264,hevc'");
   fs.writeFileSync(filename, content, encodingConfig);
 }
 


### PR DESCRIPTION
@StaZhu As you can see, it is setting --enable-decoder when it shoudl be --enable-parser. The last two version I have had to go through the .patch file manually to fix this. It doesn't cause a problem with regular HEVC, but it DOES cause a problem with AC3 or E-AC3 videos.